### PR TITLE
Example of Authelia lite on docker swarm

### DIFF
--- a/compose/lite/docker-compose-swarm.yml
+++ b/compose/lite/docker-compose-swarm.yml
@@ -1,0 +1,107 @@
+version: '3.3'
+
+#Use 'docker network create -d overlay net' to initialize your external network
+networks:
+  net:
+    external: true
+
+services:
+  authelia:
+    image: authelia/authelia
+    volumes:
+      - ./authelia:/var/lib/authelia
+      - ./configuration.yml:/etc/authelia/configuration.yml:ro
+      - ./users_database.yml:/etc/authelia/users_database.yml
+    networks:
+      - net
+    deploy:
+      labels:
+        - 'traefik.enable=true'
+        - 'traefik.http.routers.authelia.rule=Host(`auth.example.com`)'
+        - 'traefik.http.routers.authelia.entrypoints=https'
+        - 'traefik.http.routers.authelia.tls=true'
+        - 'traefik.http.routers.authelia.tls.certresolver=letsencrypt'
+        - 'traefik.http.middlewares.authelia.forwardauth.address=http://authelia:9091/api/verify?rd=https://auth.example.com'
+        - 'traefik.http.middlewares.authelia.forwardauth.trustForwardHeader=true'
+        - 'traefik.http.middlewares.authelia.forwardauth.authResponseHeaders=Remote-User, Remote-Groups'
+        - "traefik.http.routers.authelia.service=authelia"
+        - "traefik.http.services.authelia.loadbalancer.server.port=9091"
+    environment:
+      - TZ=Australia/Melbourne
+
+  redis:
+    image: redis:alpine
+    volumes:
+      - ./redis:/data
+    networks:
+      - net
+    environment:
+      - TZ=Australia/Melbourne
+
+  traefik:
+    image: traefik:v2.2
+    volumes:
+      - ./traefik/acme.json:/acme.json
+      - /var/run/docker.sock:/var/run/docker.sock
+      # .traefik.log:/var/log/traefik.log:rw
+    networks:
+      - net
+    deploy:
+      labels:
+        - 'traefik.enable=true'
+        - 'traefik.http.routers.api.rule=Host(`traefik.example.com`)'
+        - 'traefik.http.routers.api.entrypoints=https'
+        - 'traefik.http.routers.api.service=api@internal'
+        - 'traefik.http.routers.api.tls=true'
+        - 'traefik.http.routers.api.tls.certresolver=letsencrypt'
+        - 'traefik.http.routers.api.middlewares=authelia@docker'
+        - 'traefik.http.services.traefik.loadbalancer.server.port=80'
+    ports:
+      - 80:80
+      - 443:443
+      - 8080:8080  
+    command:
+      - '--api'
+      - '--providers.docker=true'
+      - '--providers.docker.exposedByDefault=false'
+      - '--providers.docker.swarmMode=true'
+      - '--entrypoints.http=true'
+      - '--entrypoints.http.address=:80'
+      - '--entrypoints.http.http.redirections.entrypoint.to=https'
+      - '--entrypoints.http.http.redirections.entrypoint.scheme=https'
+      - '--entrypoints.https=true'
+      - '--entrypoints.https.address=:443'
+      - '--certificatesResolvers.letsencrypt.acme.email=your-email@your-domain.com'
+      - '--certificatesResolvers.letsencrypt.acme.storage=acme.json'
+      - '--certificatesResolvers.letsencrypt.acme.httpChallenge.entryPoint=http'
+      - '--log=true'
+      - '--log.level=DEBUG'
+      - '--log.filepath=/var/log/traefik.log'
+
+  secure:
+    image: containous/whoami
+    networks:
+      - net
+    deploy:
+      labels:
+        - 'traefik.enable=true'
+        - 'traefik.http.routers.secure.rule=Host(`secure.example.com`)'
+        - 'traefik.http.routers.secure.entrypoints=https'
+        - 'traefik.http.routers.secure.tls=true'
+        - 'traefik.http.routers.secure.tls.certresolver=letsencrypt'
+        - 'traefik.http.routers.secure.middlewares=authelia@docker'
+        - 'traefik.http.services.secure.loadbalancer.server.port=80'
+
+  public:
+    image: containous/whoami
+    networks:
+      - net
+    deploy:
+      labels:
+        - 'traefik.enable=true'
+        - 'traefik.http.routers.public.rule=Host(`public.example.com`)'
+        - 'traefik.http.routers.public.entrypoints=https'
+        - 'traefik.http.routers.public.tls=true'
+        - 'traefik.http.routers.public.tls.certresolver=letsencrypt'
+        - 'traefik.http.routers.public.middlewares=authelia@docker'
+        - 'traefik.http.services.public.loadbalancer.server.port=80'


### PR DESCRIPTION
Just an example docker-compose file for the deployment of Authelia lite on docker swarm. Its just a modified version of the regular docker-compose file and should be compatible with the configuration and users file. Primary changes were removing depreciated options (name, exposed ports, and restart), moving the labels under deploy, enabling swarm mode on Traefik and added a loadbalencer for each available service.

The only difference in deployment would be `docker stack deploy $STACK_NAME -c docker-compose-swarm.yml` instead of `docker-compose up -d`